### PR TITLE
DTM-15226: Resolves #8.

### DIFF
--- a/tasks/helpers/getPackagePaths.js
+++ b/tasks/helpers/getPackagePaths.js
@@ -31,7 +31,7 @@ var getAvailableTypes = function(descriptor) {
 var recursivelyAccumulateRequiredPaths = function(accumPaths, hostPath) {
   accumPaths.push(hostPath);
   var source = fs.readFileSync(hostPath, {encoding: 'utf8'});
-  matchRequires(source)
+  matchRequires(source, true)
     // matchRequires returns objects with some cruft. We just care about the module paths.
     .map(result => result.name)
     // Only care about relative paths. We don't care about require statements for core modules.


### PR DESCRIPTION
Strip comments during packaging to ignore commented require statements, etc.

<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

When a `require` statement exists in code comments, it's possible for it to be evaluated during the packaging process. When the statement doesn't resolve to a known file location, an error is thrown.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://jira.corp.adobe.com/browse/DTM-15226

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using `node@v10.0.0`.

1. Pulled the latest of `master` of `reactor-packager`.
2. Ran `npm link` in `reactor-packager` directory.
3. Switched to local extension project and added `// require('./foobar.js')` to a file.
4. Ran `npm link @adobe/reactor-packager` from my local extension project directory
5. Ran `npx @adobe/reactor-packager` from my local extension project directory. Observed an unknown file error thrown.
6. Implemented fix locally in `reactor-packager`
7. Ran `npx @adobe/reactor-packager` from my local extension project directory and observed no error thrown.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.