### PR TITLE
DTM-15226 Don't include icon file when searching for required paths.

### DIFF
--- a/tasks/helpers/getPackagePaths.js
+++ b/tasks/helpers/getPackagePaths.js
@@ -52,10 +52,12 @@ var getLibPaths = function(descriptor) {
   // got at this point and we append the base path to the remaining values.
   var getPaths = R.compose(
     R.uniq,
+    R.filter(R.complement(isEmpty)),
+    R.append(descriptor.iconPath),
     R.concat(descriptor.hostedLibFiles || []),
     R.reduce(recursivelyAccumulateRequiredPaths, []),
     R.filter(R.complement(isEmpty)),
-    R.concat([descriptor.iconPath, descriptor.main]),
+    R.append(descriptor.main),
     R.pluck('libPath'),
     R.flatten,
     R.props(getAvailableTypes(descriptor))


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes a bug where, when packaging an extension, the extension developer would receive the error `Unexpected token (1:0)`

The problem is that if the extension had an icon, the icon file would be included in the list of files to search for require statements. Because the icon file is not JavaScript, the `strip-comments` process would fail when parsing the file.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DTM-15226
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Let extension developers package extensions successfully.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I ran the updated packager on a few Adobe extensions.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.