### PR TITLE
Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-packager",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-packager",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/reactor-validator": "^2.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-packager",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-packager",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/reactor-validator": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-packager",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Command line utility for packaging a Launch extension into a zip file.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-packager",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Command line utility for packaging a Launch extension into a zip file.",
   "author": {
     "name": "Adobe Systems",
@@ -22,7 +22,7 @@
     "ramda": "^0.27.0"
   },
   "bin": {
-    "reactor-packager": "./tasks/index.js"
+    "reactor-packager": "tasks/index.js"
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
Forgot to bump the version in `package.json` when making `v4.0.2`. Releasing `v4.0.3` with the same code changes as `v4.0.2`, but with the `package.json` version updated.