### PR TITLE
DTM-10297: update recommended node version 

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.ADOBE_BOT_NPM_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Launch, by Adobe, is a next-generation tag management solution enabling simplifi
 
 The extension packager is a command-line utility for packaging a Launch extension into a zip file suitable to be uploaded to Launch. While using this utility is not necessary, it will validate that your extension appears well-structured (e.g., files that are referenced exist in the directory) and make an effort to exclude anything from the zip file not necessary for the extension to operate.
 
-For more information about developing an extension for Launch, please visit our [extension development guide](https://developer.adobelaunch.com/extensions/).
+For more information about developing an extension for Launch, please visit our [extension development guide](https://experienceleague.adobe.com/docs/launch/using/extension-dev/overview.html#extension-dev).
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "reactor-packager": "tasks/index.js"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.13.0"
   }
 }


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

DTM-10297: Update links in README. Recommend minimum Erbium LTS node version.

## Related Issue

https://jira.corp.adobe.com/browse/DTM-10297

## Motivation and Context

Keeping node recommendation inline with LTS versions.

## How Has This Been Tested?

I packaged a small extension on my local machine and verified the zip contents.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Dependency Updates 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.